### PR TITLE
#43 - Display JSON Results of Address Lookup as a Table

### DIFF
--- a/app/components/ZoningTable.tsx
+++ b/app/components/ZoningTable.tsx
@@ -33,20 +33,39 @@ export function ZoningTable(props: {zoningData: string}) {
         <Box height={35}></Box>
   
         <Typography variant="h5" gutterBottom>Zoning Details</Typography>
-        {Object.entries(categories).map(([category, uses]) => (
-          <Accordion key={category} disableGutters sx={{ mb: 1, '& .MuiAccordionSummary-content': { margin: 0 }, '& .MuiAccordionDetails-root': { paddingTop: 0.25, paddingBottom: 0.25 } }}>
-            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-              <Typography variant="subtitle1" fontWeight="bold">{category.toLocaleLowerCase() == "residential" ? Name : category}</Typography>
-            </AccordionSummary>
-            <AccordionDetails>
-              {renderTable(uses)}
-            </AccordionDetails>
-          </Accordion>
-        ))}
+        {
+          Object.keys(categories).length === 0
+          ? emptyDetails()
+          : zoningDetails(categories, Name)
+        }
       </div>
     );
   };
   export default ZoningTable;
+
+  const zoningDetails = (categories: any, Name: string) => {
+    return (
+      <div>{Object.entries(categories).map(([category, uses]) => (
+        <Accordion key={category} disableGutters sx={{ mb: 1, '& .MuiAccordionSummary-content': { margin: 0 }, '& .MuiAccordionDetails-root': { paddingTop: 0.25, paddingBottom: 0.25 } }}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography variant="subtitle1" fontWeight="bold">{category.toLocaleLowerCase() == "residential" ? Name : category}</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            {renderTable(uses)}
+          </AccordionDetails>
+        </Accordion>
+      ))}
+      </div>
+    );
+  }
+
+  const emptyDetails = () => {
+    return (
+      <div>
+        No zoning details avaliable.
+      </div>
+    );
+  }
 
   const renderTable = (data: any, columnLabels=["Use", "Status"]) => {
     return (
@@ -68,12 +87,14 @@ export function ZoningTable(props: {zoningData: string}) {
                   </TableRow>
                 ));
               }
-              return (
-                <TableRow key={key}>
-                  <TableCell>{key}</TableCell>
-                  <TableCell>{value.toString()}</TableCell>
-                </TableRow>
-              );
+              if (value) {
+                return (
+                  <TableRow key={key}>
+                    <TableCell>{key}</TableCell>
+                    <TableCell>{value.toString()}</TableCell>
+                  </TableRow>
+                );
+              }
             })}
           </TableBody>
         </Table>

--- a/app/components/ZoningTable.tsx
+++ b/app/components/ZoningTable.tsx
@@ -3,6 +3,7 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  Box,
   Table,
   TableBody,
   TableCell,
@@ -19,7 +20,7 @@ export function ZoningTable(props: {zoningData: string}) {
     const { Name, ...categories } = zoningInfo;
   
     return (
-      <div>
+      <div style={{ padding: '1rem', maxWidth: '1500px', margin: '0 auto', marginBottom: 100 }}>
         <Typography variant="h5" gutterBottom>Address Information</Typography>
         {renderTable({
           Address: address,
@@ -27,13 +28,15 @@ export function ZoningTable(props: {zoningData: string}) {
           Longitude: coordinates.lon,
           'Zoning Code': zoningCode,
           'Zoning Name': Name
-        })}
+        }, ["Detail", "Value"])}
+
+        <Box height={35}></Box>
   
         <Typography variant="h5" gutterBottom>Zoning Details</Typography>
         {Object.entries(categories).map(([category, uses]) => (
-          <Accordion key={category} defaultExpanded>
+          <Accordion key={category} disableGutters sx={{ mb: 1, '& .MuiAccordionSummary-content': { margin: 0 }, '& .MuiAccordionDetails-root': { paddingTop: 0.25, paddingBottom: 0.25 } }}>
             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-              <Typography variant="h6">{category}</Typography>
+              <Typography variant="subtitle1" fontWeight="bold">{category}</Typography>
             </AccordionSummary>
             <AccordionDetails>
               {renderTable(uses)}
@@ -45,14 +48,14 @@ export function ZoningTable(props: {zoningData: string}) {
   };
   export default ZoningTable;
 
-  const renderTable = (data: any) => {
+  const renderTable = (data: any, columnLabels=["Use", "Status"]) => {
     return (
-      <TableContainer component={Paper} sx={{ marginY: 2 }}>
+      <TableContainer component={Paper} sx={{ marginY: 1 }}>
         <Table size="small">
           <TableHead>
             <TableRow>
-              <TableCell><strong>Use</strong></TableCell>
-              <TableCell><strong>Status</strong></TableCell>
+              <TableCell sx={{ color: "white" }}><strong>{columnLabels[0]}</strong></TableCell>
+              <TableCell sx={{ color: "white" }}><strong>{columnLabels[1]}</strong></TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/app/components/ZoningTable.tsx
+++ b/app/components/ZoningTable.tsx
@@ -36,7 +36,7 @@ export function ZoningTable(props: {zoningData: string}) {
         {Object.entries(categories).map(([category, uses]) => (
           <Accordion key={category} disableGutters sx={{ mb: 1, '& .MuiAccordionSummary-content': { margin: 0 }, '& .MuiAccordionDetails-root': { paddingTop: 0.25, paddingBottom: 0.25 } }}>
             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-              <Typography variant="subtitle1" fontWeight="bold">{category}</Typography>
+              <Typography variant="subtitle1" fontWeight="bold">{category.toLocaleLowerCase() == "residential" ? Name : category}</Typography>
             </AccordionSummary>
             <AccordionDetails>
               {renderTable(uses)}

--- a/app/components/ZoningTable.tsx
+++ b/app/components/ZoningTable.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  Paper
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
+export function ZoningTable(props: {zoningData: string}) {
+    const { address, coordinates, zoningCode, zoningInfo } = JSON.parse(props.zoningData);
+    const { Name, ...categories } = zoningInfo;
+  
+    return (
+      <div>
+        <Typography variant="h5" gutterBottom>Address Information</Typography>
+        {renderTable({
+          Address: address,
+          Latitude: coordinates.lat,
+          Longitude: coordinates.lon,
+          'Zoning Code': zoningCode,
+          'Zoning Name': Name
+        })}
+  
+        <Typography variant="h5" gutterBottom>Zoning Details</Typography>
+        {Object.entries(categories).map(([category, uses]) => (
+          <Accordion key={category} defaultExpanded>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="h6">{category}</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              {renderTable(uses)}
+            </AccordionDetails>
+          </Accordion>
+        ))}
+      </div>
+    );
+  };
+  export default ZoningTable;
+
+  const renderTable = (data: any) => {
+    return (
+      <TableContainer component={Paper} sx={{ marginY: 2 }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell><strong>Use</strong></TableCell>
+              <TableCell><strong>Status</strong></TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {Object.entries(data).map(([key, value]) => {
+              if (typeof value === 'object') {
+                return Object.entries(value).map(([subKey, subValue]) => (
+                  <TableRow key={`${key}-${subKey}`}>
+                    <TableCell>{`${key} - ${subKey}`}</TableCell>
+                    <TableCell>{subValue}</TableCell>
+                  </TableRow>
+                ));
+              }
+              return (
+                <TableRow key={key}>
+                  <TableCell>{key}</TableCell>
+                  <TableCell>{value.toString()}</TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    );
+  };

--- a/app/questionnaire/page.tsx
+++ b/app/questionnaire/page.tsx
@@ -90,7 +90,7 @@ export default function QuestionnairePage() {
       </form>
       {
         zoningResult && (
-          <div >
+          <div style={{padding: '30px'}}>
             <h2 >Zoning Information</h2>
             <ZoningTable zoningData={JSON.stringify(zoningResult, null, 2)} />
           </div>

--- a/app/questionnaire/page.tsx
+++ b/app/questionnaire/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import ZoningTable from '../components/ZoningTable';
 
 export default function QuestionnairePage() {
   const [address, setAddress] = useState('');
@@ -91,9 +92,7 @@ export default function QuestionnairePage() {
         zoningResult && (
           <div >
             <h2 >Zoning Information</h2>
-            <pre >
-              {JSON.stringify(zoningResult, null, 2)}
-            </pre>
+            <ZoningTable zoningData={JSON.stringify(zoningResult, null, 2)} />
           </div>
         )
       }

--- a/app/types/zoning_result.ts
+++ b/app/types/zoning_result.ts
@@ -1,0 +1,9 @@
+export type ZoningResult = {
+    subtitle: string,
+    info: ZoningInfo[]
+}
+
+export type ZoningInfo = {
+    use: string,
+    permission: string
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/signature-v4-crt": "^3.451.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@mui/icons-material": "^7.0.2",
         "@mui/material": "^7.0.2",
         "@types/node": "20.9.0",
         "@types/react": "18.2.37",
@@ -1492,6 +1493,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.0.2.tgz",
+      "integrity": "sha512-Bo57PFLOqXOqPNrXjd8AhzH5s6TCsNUQbvnQ0VKZ8D+lIlteqKnrk/O1luMJUc/BXONK7BfIdTdc7qOnXYbMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.0.2",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@aws-sdk/signature-v4-crt": "^3.451.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@mui/icons-material": "^7.0.2",
     "@mui/material": "^7.0.2",
     "@types/node": "20.9.0",
     "@types/react": "18.2.37",


### PR DESCRIPTION
Create a ZoningTable component, which the Questionnaire page displays after receiving valid JSON data from the API. The data is then displayed as a MaterialUI table with an Address Information table and a dynamically created Zoning Details accordion with tables under each section.

I have tested this for cases where Address Information is missing (such as Zoning Name) and when Zoning Details is passed as an empty object such as `{}`.

Closes #43 