### PR TITLE
#10 Add User Dashboard and Report Pages

### DIFF
--- a/app/api/zoning/history/[timestamp]/route.ts
+++ b/app/api/zoning/history/[timestamp]/route.ts
@@ -3,11 +3,14 @@ import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { docClient } from "@/app/lib/dynamodb";
 import { auth0 } from "@/lib/auth0";
 
-export async function GET(params: {timestamp: string}) {
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: { timestamp: string } }
+) {
     try {
         const { user } = await auth0.getSession();
         const userId = user.sub;
-        const timestamp = params.timestamp;
+        const timestamp: number = parseInt(params.timestamp);
 
         if (!timestamp) {
             return Response.json({error: "No timestamp in request"})
@@ -26,8 +29,9 @@ export async function GET(params: {timestamp: string}) {
             return NextResponse.json({ error: "Item not found" }, { status: 404 });
         }
 
-        return NextResponse.json(response);
+        return NextResponse.json(response.Item.zoningData);
     } catch (e: any) {
+        console.error("API error:", e);
         return NextResponse.json({error: e.message}, {status: 500});
     }
 }

--- a/app/api/zoning/history/[timestamp]/route.ts
+++ b/app/api/zoning/history/[timestamp]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse, NextRequest } from "next/server";
+import { GetCommand } from "@aws-sdk/lib-dynamodb";
+import { docClient } from "@/app/lib/dynamodb";
+import { auth0 } from "@/lib/auth0";
+
+export async function GET(params: {timestamp: string}) {
+    try {
+        const { user } = await auth0.getSession();
+        const userId = user.sub;
+        const timestamp = params.timestamp;
+
+        if (!timestamp) {
+            return Response.json({error: "No timestamp in request"})
+        }
+
+        const response = await docClient.send(
+            new GetCommand({
+                TableName: process.env.AWS_DATABASE_TABLE,
+                Key: {
+                    userId: userId,
+                    timestamp: timestamp
+                }
+            })
+        );
+        if (!response.Item) {
+            return NextResponse.json({ error: "Item not found" }, { status: 404 });
+        }
+
+        return NextResponse.json(response);
+    } catch (e: any) {
+        return NextResponse.json({error: e.message}, {status: 500});
+    }
+}

--- a/app/api/zoning/route.ts
+++ b/app/api/zoning/route.ts
@@ -25,10 +25,7 @@ export async function POST(request: Request) {
                 Item: {
                     userId,
                     timestamp,
-                    address: result.address,
-                    zoningCode: result.zoningCode,
-                    coordinates: result.coordinates,
-                    zoningInfo: result.zoningInfo
+                    zoningData: result
                 }
             })
         )

--- a/app/api/zoning/route.ts
+++ b/app/api/zoning/route.ts
@@ -25,6 +25,7 @@ export async function POST(request: Request) {
                 Item: {
                     userId,
                     timestamp,
+                    address: result.address,
                     zoningData: result
                 }
             })

--- a/app/components/LoadingSpinner.tsx
+++ b/app/components/LoadingSpinner.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { CircularProgress, Box } from '@mui/material';
+
+export default function LoadingSpinner() {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '100vh', // full viewport height
+      }}
+    >
+      <CircularProgress />
+    </Box>
+  );
+}

--- a/app/components/Nav.tsx
+++ b/app/components/Nav.tsx
@@ -1,46 +1,41 @@
-// app/components/Nav.tsx
-import { AppBar, Box, Button, Toolbar, Typography } from '@mui/material';
+import { AppBar, Box, Button, Toolbar } from '@mui/material';
 import Link from 'next/link';
 import { BuiltItLogo } from './BuiltItLogo';
 
-// This is our navigation bar at the top of the website.
 export default function Nav() {
   return (
     <AppBar position="static" color="default" elevation={1} sx={{ backgroundColor: '#e8f5e9' }}>
-      <Toolbar sx={{ minHeight: '64px !important' }}>
+      <Toolbar sx={{ minHeight: '64px !important', display: 'flex', alignItems: 'center' }}>
         
-        <Box sx={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
+        {/* Container for logo + links with flexGrow */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexGrow: 1 }}>
           <Link href="/" style={{ textDecoration: 'none' }}>
             <Box
               sx={{
-                transform: 'scale(1.3)',       // Scale the logo up
-                transformOrigin: 'left center', // Anchor the scale to the left
-                height: '70px',                 // Restrict height so toolbar stays stable
+                flexShrink: 0,               // Prevent shrinking
+                width: 175,                 // Fixed width matching logo size
+                height: 70,                 // Fixed height
                 display: 'flex',
                 alignItems: 'center',
+                // Removed transform: scale() for safer sizing
               }}
             >
-              <BuiltItLogo height={75} width={175}/>
+              <BuiltItLogo height={70} width={175} />
             </Box>
           </Link>
-        </Box>
-        
-        <Box sx={{flexGrow: 15}}>
-          <Link href="/dashboard" style={{color: "black", textDecoration: 'none'}}>
-            <Typography
-                variant="h6"
-                noWrap
-                sx={{
-                mr: 2,
-                fontWeight: 400,
-                
-                }}
-            >
-                Dashboard
-            </Typography>
-        </Link>
+
+          {/* Navigation links right next to the logo with margin-left */}
+          <Box sx={{ display: 'flex', gap: 2, ml: 2 }}>
+            <Button color="inherit" href="/questionnaire">
+              New Report
+            </Button>
+            <Button color="inherit" href="/dashboard">
+              Dashboard
+            </Button>
+          </Box>
         </Box>
 
+        {/* Logout button on the far right */}
         <Box>
           <Button
             variant="outlined"

--- a/app/components/Nav.tsx
+++ b/app/components/Nav.tsx
@@ -1,5 +1,5 @@
 // app/components/Nav.tsx
-import { AppBar, Box, Button, Toolbar } from '@mui/material';
+import { AppBar, Box, Button, Toolbar, Typography } from '@mui/material';
 import Link from 'next/link';
 import { BuiltItLogo } from './BuiltItLogo';
 
@@ -25,6 +25,22 @@ export default function Nav() {
           </Link>
         </Box>
         
+        <Box sx={{flexGrow: 15}}>
+          <Link href="/dashboard" style={{color: "black", textDecoration: 'none'}}>
+            <Typography
+                variant="h6"
+                noWrap
+                sx={{
+                mr: 2,
+                fontWeight: 400,
+                
+                }}
+            >
+                Dashboard
+            </Typography>
+        </Link>
+        </Box>
+
         <Box>
           <Button
             variant="outlined"

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,23 +3,26 @@
 import { useEffect, useState } from "react"
 import Nav from "../components/Nav"
 import { Card, CardActionArea, CardContent, Typography } from "@mui/material";
+import { useRouter } from "next/navigation";
 
 export default function Dashboard() {
 
+    const router = useRouter();
+    
     const [data, setData] = useState<any | undefined>();
 
     useEffect(() => {
-    fetch("/api/zoning/history")
-        .then((r) => r.json())
-        .then((d) => {
-        const formatted = d.map((item: any) => {
-            const date = new Date(item.timestamp * 1000); // Convert to milliseconds
-            return {
-            ...item,
-            formattedDate: `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`
-            };
-        });
-        setData(formatted);
+        fetch("/api/zoning/history")
+            .then((r) => r.json())
+            .then((d) => {
+            const formatted = d.map((item: any) => {
+                const date = new Date(item.timestamp * 1000); // Convert to milliseconds
+                return {
+                ...item,
+                formattedDate: `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`
+                };
+            });
+            setData(formatted);
         });
     }, []);
 
@@ -31,7 +34,7 @@ export default function Dashboard() {
                     data.map((zoning, i) => 
                         <Card key={i}>
                             <CardActionArea
-                                onClick={() => {}}
+                                onClick={() => router.push(`/reports/${zoning.userId}/${zoning.timestamp}`)}
                                 sx={{
                                     '&:hover': {
                                         backgroundColor: '#95f098'

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useState } from "react"
+import Nav from "../components/Nav"
+import { Card, CardActionArea, CardContent, Typography } from "@mui/material";
+
+export default function Dashboard() {
+
+    const [data, setData] = useState<any | undefined>();
+
+    useEffect(() => {
+    fetch("/api/zoning/history")
+        .then((r) => r.json())
+        .then((d) => {
+        const formatted = d.map((item: any) => {
+            const date = new Date(item.timestamp * 1000); // Convert to milliseconds
+            return {
+            ...item,
+            formattedDate: `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`
+            };
+        });
+        setData(formatted);
+        });
+    }, []);
+
+
+    useEffect(()=> {
+        console.log(data)
+    }, [data])
+
+    if (data) {
+        return (
+            <div>
+                <Nav />
+                {
+                    data.map((zoning, i) => 
+                        <Card key={i}>
+                            <CardActionArea>
+                                <CardContent>
+                                    <Typography variant="h5" component="div">
+                                        {zoning.address}
+                                    </Typography>
+                                    <Typography variant="body2" color="text.secondary">
+                                        {zoning.formattedDate}
+                                    </Typography>
+                                </CardContent>
+                            </CardActionArea>
+                        </Card>
+                    )
+                }
+                
+            </div>
+        )
+    } else {
+        return (
+            <div>
+                Loading...
+            </div>
+        )
+    }
+    
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -34,7 +34,7 @@ export default function Dashboard() {
                     data.map((zoning, i) => 
                         <Card key={i}>
                             <CardActionArea
-                                onClick={() => router.push(`/reports/${zoning.userId}/${zoning.timestamp}`)}
+                                onClick={() => router.push(`/reports/${zoning.timestamp}`)}
                                 sx={{
                                     '&:hover': {
                                         backgroundColor: '#95f098'

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 import Nav from "../components/Nav"
 import { Card, CardActionArea, CardContent, Typography } from "@mui/material";
 import { useRouter } from "next/navigation";
+import LoadingSpinner from "../components/LoadingSpinner";
 
 export default function Dashboard() {
 
@@ -58,9 +59,7 @@ export default function Dashboard() {
         )
     } else {
         return (
-            <div>
-                Loading...
-            </div>
+            <LoadingSpinner />
         )
     }
     

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -23,11 +23,6 @@ export default function Dashboard() {
         });
     }, []);
 
-
-    useEffect(()=> {
-        console.log(data)
-    }, [data])
-
     if (data) {
         return (
             <div>
@@ -35,7 +30,14 @@ export default function Dashboard() {
                 {
                     data.map((zoning, i) => 
                         <Card key={i}>
-                            <CardActionArea>
+                            <CardActionArea
+                                onClick={() => {}}
+                                sx={{
+                                    '&:hover': {
+                                        backgroundColor: '#95f098'
+                                    }
+                                }}
+                            >
                                 <CardContent>
                                     <Typography variant="h5" component="div">
                                         {zoning.address}

--- a/app/reports/[timestamp]/page.tsx
+++ b/app/reports/[timestamp]/page.tsx
@@ -1,12 +1,14 @@
+'use client';
+
+import Nav from '@/app/components/Nav';
 import ZoningTable from '@/app/components/ZoningTable';
-import { useRouter } from 'next/router';
+import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 export default function ItemPage() {
-    const router = useRouter();
-    const { timestamp } = router.query;
+    const { timestamp } = useParams();
 
-    const [data, setData] = useState<any | null>();
+    const [data, setData] = useState<any | null>(null);
 
     useEffect(() => {
         fetch(`/api/zoning/history/${timestamp}`)
@@ -16,9 +18,14 @@ export default function ItemPage() {
         });
     }, []);
 
-  return (
-    <div>
-        {data ? <ZoningTable zoningData={data} /> : <div>Loading</div>}
-    </div>
+    return (
+        <>
+            <Nav />
+            {data ? (
+                <ZoningTable zoningData={JSON.stringify(data, null, 2)} />
+            ) : (
+                <div>Loading...</div>
+            )}
+        </>
   );
 }

--- a/app/reports/[timestamp]/page.tsx
+++ b/app/reports/[timestamp]/page.tsx
@@ -4,6 +4,7 @@ import Nav from '@/app/components/Nav';
 import ZoningTable from '@/app/components/ZoningTable';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import LoadingSpinner from '@/app/components/LoadingSpinner';
 
 export default function ItemPage() {
     const { timestamp } = useParams();
@@ -24,7 +25,7 @@ export default function ItemPage() {
             {data ? (
                 <ZoningTable zoningData={JSON.stringify(data, null, 2)} />
             ) : (
-                <div>Loading...</div>
+                <LoadingSpinner />
             )}
         </>
   );

--- a/app/reports/[timestamp]/page.tsx
+++ b/app/reports/[timestamp]/page.tsx
@@ -1,3 +1,4 @@
+import ZoningTable from '@/app/components/ZoningTable';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
@@ -11,20 +12,13 @@ export default function ItemPage() {
         fetch(`/api/zoning/history/${timestamp}`)
             .then((r) => r.json())
             .then((d) => {
-            const formatted = d.map((item: any) => {
-                const date = new Date(item.timestamp * 1000); // Convert to milliseconds
-                return {
-                ...item,
-                formattedDate: `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`
-                };
-            });
-            setData(formatted);
+            setData(d);
         });
     }, []);
 
   return (
     <div>
-        Hi
+        {data ? <ZoningTable zoningData={data} /> : <div>Loading</div>}
     </div>
   );
 }

--- a/app/reports/[timestamp]/page.tsx
+++ b/app/reports/[timestamp]/page.tsx
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+export default function ItemPage() {
+    const router = useRouter();
+    const { timestamp } = router.query;
+
+    const [data, setData] = useState<any | null>();
+
+    useEffect(() => {
+        fetch(`/api/zoning/history/${timestamp}`)
+            .then((r) => r.json())
+            .then((d) => {
+            const formatted = d.map((item: any) => {
+                const date = new Date(item.timestamp * 1000); // Convert to milliseconds
+                return {
+                ...item,
+                formattedDate: `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`
+                };
+            });
+            setData(formatted);
+        });
+    }, []);
+
+  return (
+    <div>
+        Hi
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3770,14 +3770,12 @@
         "node": ">= 6"
       }
     },
-
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
-
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",


### PR DESCRIPTION
Closes #10 
Added /dashboard page which displays every report saved to the signed-in user. Clicking a report card redirects to /reports/:timestamp.

Changed storing a report to the database to include all of the JSON under `zoningData` to allow the ZoningTable to easily use it.

Added /api/history/:timestamp, which gets a user's report with the specified timestamp.